### PR TITLE
The messagesBaseUrl changes to baseURL mid project

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,11 +419,11 @@ const app = express();
 app.use( bodyParser.json() );
 app.use( express.static( __dirname + '/../public/build' ) );
 
-const baseURL = "/api/messages";
-app.post( baseURL, mc.create );
-app.get( baseURL, mc.read );
-app.put( `${baseURL}/:id`, mc.update );
-app.delete( `${baseURL}/:id`, mc.delete );
+const  messagesBaseUrl = "/api/messages";
+app.post(  messagesBaseUrl, mc.create );
+app.get(  messagesBaseUrl, mc.read );
+app.put( `${ messagesBaseUrl}/:id`, mc.update );
+app.delete( `${ messagesBaseUrl}/:id`, mc.delete );
 
 const port = 3001;
 app.listen( port, () => { console.log(`Server listening on port ${port}.`); } );


### PR DESCRIPTION
The variable messagesBaseUrl changes to baseURL mid project in the readme without explanation. I am proposing that the variable be changed to messagesBaseUrl to be consistent throughout the README.